### PR TITLE
Improvements: send filename to server. pass file data to callbacks.

### DIFF
--- a/s3upload.coffee
+++ b/s3upload.coffee
@@ -46,7 +46,7 @@ class window.S3Upload
 		this_s3upload = this
 
 		xhr = new XMLHttpRequest()
-		type = opts && opts.type || file.type
+		type = opts && opts.type || file.type || "application/octet-stream"
 		name = opts && opts.name || file.name
 		xhr.open 'GET', @s3_sign_put_url + '?s3_object_type=' + type + '&s3_object_name=' + encodeURIComponent(name), true
 
@@ -70,7 +70,7 @@ class window.S3Upload
 	uploadToS3: (file, url, public_url, opts) ->
 		this_s3upload = this
 
-		type = opts && opts.type || file.type
+		type = opts && opts.type || file.type || "application/octet-stream"
 
 		xhr = @createCORSRequest 'PUT', url
 		if !xhr

--- a/s3upload.js
+++ b/s3upload.js
@@ -57,7 +57,7 @@
       var name, this_s3upload, type, xhr;
       this_s3upload = this;
       xhr = new XMLHttpRequest();
-      type = opts && opts.type || file.type;
+      type = opts && opts.type || file.type || "application/octet-stream";
       name = opts && opts.name || file.name;
       xhr.open('GET', this.s3_sign_put_url + '?s3_object_type=' + type + '&s3_object_name=' + encodeURIComponent(name), true);
       xhr.overrideMimeType('text/plain; charset=x-user-defined');
@@ -82,7 +82,7 @@
     S3Upload.prototype.uploadToS3 = function(file, url, public_url, opts) {
       var this_s3upload, type, xhr;
       this_s3upload = this;
-      type = opts && opts.type || file.type;
+      type = opts && opts.type || file.type || "application/octet-stream";
       xhr = this.createCORSRequest('PUT', url);
       if (!xhr) {
         this.onError('CORS not supported');


### PR DESCRIPTION
1. Pass uploaded filename to /signS3put so that the server can return a namespaced filename such as "{12 character random}-{original filename}"
2. Remove unnecessary `decodeURIComponent` (#1) - just remove the unnecessary urlencode on the server side in your tutorial 
3. Pass filedata to the callbacks (so you can keep track of filesize, original filename, etc.)
